### PR TITLE
Add automatic 90-day data cleanup logic

### DIFF
--- a/server/utils/dataCleanup.js
+++ b/server/utils/dataCleanup.js
@@ -1,0 +1,15 @@
+import Activity from "../models/Activity.js";
+
+export const deleteOldActivity = async () => {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 90);
+
+  try {
+    const result = await Activity.deleteMany({ createdAt: { $lt: cutoff } });
+    console.log(
+      `🧹 Deleted ${result.deletedCount} activity records older than 90 days.`
+    );
+  } catch (err) {
+    console.error("Error during automatic data cleanup:", err);
+  }
+};

--- a/server/utils/dataCleanupp.js
+++ b/server/utils/dataCleanupp.js
@@ -1,0 +1,15 @@
+import Activity from "../models/Activity.js";
+
+export const deleteOldActivity = async () => {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 90);
+
+  try {
+    const result = await Activity.deleteMany({ createdAt: { $lt: cutoff } });
+    console.log(
+      `🧹 Deleted ${result.deletedCount} activity records older than 90 days.`
+    );
+  } catch (err) {
+    console.error("Error during automatic data cleanup:", err);
+  }
+};


### PR DESCRIPTION
Added a new utility `dataCleanupp.js` under `server/utils`.

- Deletes `Activity` records older than 90 days
- Designed to be scheduled with a cron job from the main server
- Logs the number of deleted records and handles errors gracefully

This PR addresses Issue #86.