### PR TITLE
🔔 Enhance reminder form UI: time before repeat, instant rendering, Wh…

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import Registration from "./pages/Registration";
 import Dashboard from "./pages/Dashboard";
 import AuthSuccess from "./pages/AuthSuccess";
 import Footer from "./components/Footer";
+import Reminders from "./pages/Reminders"; // ✅ New Import
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
         <Route path="/register" element={<Registration />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/auth/success" element={<AuthSuccess />} />
+        <Route path="/reminders" element={<Reminders />} /> {/* ✅ New Route */} 
       </Routes>
       <Footer />
     </AuthProvider>

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import BarChart from "../components/charts/BarChart";
 import AppList from "../components/charts/AppList";
-import { trackTimeOnDomain } from "../utils/tracker"; // ✅ Adjust path if needed
+import { trackTimeOnDomain } from "../utils/tracker"; // ✅ Adjust path if needed 
 
 const StatCard = ({ title, value, color }) =>
   <div className={`p-4 rounded-xl shadow-md text-white ${color}`}>
@@ -88,11 +88,7 @@ const Dashboard = () => {
         {/* Stats */}
         <StatCard title="Time At Work" value="2 h 43 min" color="bg-blue-500" />
         <StatCard title="Creativity" value="2 h 32 min" color="bg-purple-500" />
-        <StatCard
-          title="Communication"
-          value="1 h 21 min"
-          color="bg-cyan-400"
-        />
+        <StatCard title="Communication" value="1 h 21 min" color="bg-cyan-400" />
         <StatCard title="Productivity" value="1 h 21 min" color="bg-pink-400" />
         <StatCard title="Others" value="41 min" color="bg-green-400" />
 
@@ -102,6 +98,15 @@ const Dashboard = () => {
           <div className="h-48 overflow-y-auto">
             <AppList />
           </div>
+        </div>
+
+        {/* Reminders Card */}
+        <div className="col-span-1 bg-white dark:bg-gray-800 rounded-xl shadow-md p-4 hover:shadow-lg transition-all cursor-pointer"
+             onClick={() => window.location.href = "/reminders"}>
+          <h2 className="text-md font-semibold mb-2">⏰ Reminders</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Set break alerts, usage limits, and custom reminders.
+          </p>
         </div>
       </div>
 

--- a/client/src/pages/Reminders.jsx
+++ b/client/src/pages/Reminders.jsx
@@ -97,7 +97,7 @@ const Reminders = () => {
       return (
         <div className="space-y-3">
           <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
-            🎯 Target
+            Target
           </label>
           <select
             name="targetType"
@@ -116,10 +116,10 @@ const Reminders = () => {
               onChange={handleChange}
               className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
             >
-              <option value="productivity">📊 Productivity</option>
-              <option value="creativity">🎨 Creativity</option>
-              <option value="communication">💬 Communication</option>
-              <option value="others">🔧 Others</option>
+              <option value="productivity">Productivity</option>
+              <option value="creativity">Creativity</option>
+              <option value="communication">Communication</option>
+              <option value="others">Others</option>
             </select>
           ) : (
             <input
@@ -137,7 +137,7 @@ const Reminders = () => {
       return (
         <div className="space-y-3">
           <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
-            🚫 Domain to block
+            Domain to block
           </label>
           <input
             type="text"
@@ -218,7 +218,7 @@ const Reminders = () => {
     return (
       <div className="space-y-3">
         <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
-          ⏰ Time to trigger {form.type === "block" ? "block" : "alert"}
+          Time to trigger {form.type === "block" ? "block" : "alert"}
         </label>
         <div className="grid grid-cols-3 gap-3">
           <div>
@@ -313,9 +313,9 @@ const Reminders = () => {
                     onChange={handleChange}
                     className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
                   >
-                    <option value="alert">🔔 Alert</option>
-                    <option value="block">🚫 Block</option>
-                    <option value="custom">⚡ Custom</option>
+                    <option value="alert">Alert</option>
+                    <option value="block">Block</option>
+                    <option value="custom">Custom</option>
                   </select>
                 </div>
 
@@ -323,7 +323,7 @@ const Reminders = () => {
                 {form.type === "custom" && (
                   <div className="space-y-3">
                     <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
-                      🏷️ Reminder Name
+                      Reminder Name
                     </label>
                     <input
                       type="text"
@@ -339,7 +339,7 @@ const Reminders = () => {
                 {/* Reminder Message */}
                 <div className="space-y-3">
                   <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
-                    💬 Reminder Message
+                    Reminder Message
                   </label>
                   <textarea
                     name="message"
@@ -360,7 +360,7 @@ const Reminders = () => {
                 {/* Notification Type */}
                 <div className="space-y-3">
                   <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
-                    🔊 Notification Type
+                    Notification Type
                   </label>
                   <div className="grid grid-cols-2 gap-4">
                     <label className="flex items-center p-3 bg-white dark:bg-slate-800 rounded-xl border-2 border-emerald-200 dark:border-emerald-700 cursor-pointer hover:bg-emerald-50 dark:hover:bg-slate-700 transition-colors">
@@ -372,7 +372,7 @@ const Reminders = () => {
                         className="w-4 h-4 text-emerald-600 bg-gray-100 border-gray-300 rounded focus:ring-emerald-500 dark:focus:ring-emerald-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
                       />
                       <span className="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300">
-                        🌐 Browser
+                        Browser
                       </span>
                     </label>
                     <label className="flex items-center p-3 bg-white dark:bg-slate-800 rounded-xl border-2 border-emerald-200 dark:border-emerald-700 cursor-pointer hover:bg-emerald-50 dark:hover:bg-slate-700 transition-colors">
@@ -384,7 +384,7 @@ const Reminders = () => {
                         className="w-4 h-4 text-emerald-600 bg-gray-100 border-gray-300 rounded focus:ring-emerald-500 dark:focus:ring-emerald-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
                       />
                       <span className="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300">
-                        🔔 Sound
+                        Sound
                       </span>
                     </label>
                   </div>
@@ -448,16 +448,16 @@ const Reminders = () => {
                           </p>
                           <div className="flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400">
                             <span className="bg-gray-100 dark:bg-gray-600 px-2 py-1 rounded-full">
-                              ⏰ {reminder.hours}h {reminder.minutes}m {reminder.seconds}s
+                              {reminder.hours}h {reminder.minutes}m {reminder.seconds}s
                             </span>
                             {reminder.repeatOption === "custom" && (
                               <span className="bg-gray-100 dark:bg-gray-600 px-2 py-1 rounded-full">
-                                🔄 {reminder.customRepeatHours}h {reminder.customRepeatMinutes}m {reminder.customRepeatSeconds}s
+                                {reminder.customRepeatHours}h {reminder.customRepeatMinutes}m {reminder.customRepeatSeconds}s
                               </span>
                             )}
                             {reminder.repeatOption !== "never" && reminder.repeatOption !== "custom" && (
                               <span className="bg-gray-100 dark:bg-gray-600 px-2 py-1 rounded-full">
-                                🔄 {reminder.repeatOption}
+                                {reminder.repeatOption}
                               </span>
                             )}
                           </div>

--- a/client/src/pages/Reminders.jsx
+++ b/client/src/pages/Reminders.jsx
@@ -283,7 +283,7 @@ const Reminders = () => {
         {/* Header */}
         <div className="text-center mb-8">
           <h1 className="text-4xl sm:text-5xl font-bold bg-gradient-to-r from-emerald-600 to-teal-600 bg-clip-text text-transparent mb-2">
-            🧠 Smart Reminder Settings
+             Smart Reminder Settings
           </h1>
           <p className="text-gray-600 dark:text-gray-300 text-lg">
             Set up intelligent reminders to boost your productivity
@@ -351,13 +351,10 @@ const Reminders = () => {
                   />
                 </div>
 
-                {/* Target Inputs */}
                 {renderTargetInputs()}
 
-                {/* Time Input */}
                 {renderTimeInput()}
 
-                {/* Repeat Options */}
                 {renderRepeatOptions()}
 
                 {/* Notification Type */}

--- a/client/src/pages/Reminders.jsx
+++ b/client/src/pages/Reminders.jsx
@@ -1,0 +1,490 @@
+import React, { useEffect, useState, useRef } from "react";
+import axios from "axios";
+
+const Reminders = () => {
+  const [reminders, setReminders] = useState([]);
+  const [form, setForm] = useState({
+    type: "alert",
+    reminderName: "",
+    message: "",
+    targetType: "category",
+    targetValue: "productivity",
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    repeatOption: "never",
+    customRepeatHours: 0,
+    customRepeatMinutes: 0,
+    customRepeatSeconds: 0,
+    notificationTypes: ["browser"] 
+  });
+
+  const remindersEndRef = useRef(null);
+  const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:3000/api";
+
+  useEffect(() => {
+    fetchReminders();
+  }, []);
+
+  const fetchReminders = async () => {
+    try {
+      const res = await axios.get(`${API_BASE_URL}/reminders/user`, {
+        withCredentials: true
+      });
+      setReminders(res.data);
+    } catch (err) {
+      console.error("Error fetching reminders:", err);
+    }
+  };
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    if (type === "checkbox") {
+      const updated = new Set(form.notificationTypes);
+      checked ? updated.add(value) : updated.delete(value);
+      setForm({ ...form, notificationTypes: Array.from(updated) });
+    } else if (name === "targetType") {
+      setForm({
+        ...form,
+        targetType: value,
+        targetValue: value === "category" ? "productivity" : ""
+      });
+    } else {
+      setForm({ ...form, [name]: value });
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await axios.post(`${API_BASE_URL}/reminders/add`, form, {
+        withCredentials: true
+      });
+      setReminders((prev) => [...prev, res.data.reminder]);
+      setForm({
+        type: "alert",
+        reminderName: "",
+        message: "",
+        targetType: "category",
+        targetValue: "productivity",
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+        repeatOption: "never",
+        customRepeatHours: 0,
+        customRepeatMinutes: 0,
+        customRepeatSeconds: 0,
+        notificationTypes: ["browser"]
+      });
+    } catch (err) {
+      console.error("Error creating reminder:", err);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    try {
+      await axios.delete(`${API_BASE_URL}/reminders/${id}`, {
+        withCredentials: true
+      });
+      setReminders((prev) => prev.filter((r) => r._id !== id));
+    } catch (err) {
+      console.error("Error deleting reminder:", err);
+    }
+  };
+
+  const renderTargetInputs = () => {
+    if (form.type === "alert") {
+      return (
+        <div className="space-y-3">
+          <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+            🎯 Target
+          </label>
+          <select
+            name="targetType"
+            value={form.targetType}
+            onChange={handleChange}
+            className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
+          >
+            <option value="category">Category</option>
+            <option value="domain">Other Domain</option>
+          </select>
+
+          {form.targetType === "category" ? (
+            <select
+              name="targetValue"
+              value={form.targetValue}
+              onChange={handleChange}
+              className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
+            >
+              <option value="productivity">📊 Productivity</option>
+              <option value="creativity">🎨 Creativity</option>
+              <option value="communication">💬 Communication</option>
+              <option value="others">🔧 Others</option>
+            </select>
+          ) : (
+            <input
+              type="text"
+              name="targetValue"
+              value={form.targetValue}
+              onChange={handleChange}
+              className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
+              placeholder="e.g. youtube.com"
+            />
+          )}
+        </div>
+      );
+    } else if (form.type === "block") {
+      return (
+        <div className="space-y-3">
+          <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+            🚫 Domain to block
+          </label>
+          <input
+            type="text"
+            name="targetValue"
+            value={form.targetValue}
+            onChange={handleChange}
+            className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
+            placeholder="e.g. facebook.com"
+          />
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const renderRepeatOptions = () => {
+    if (form.type === "alert") {
+      return (
+        <div className="space-y-3">
+          <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+            🔄 Repeat (after main alert)
+          </label>
+          <select
+            name="repeatOption"
+            value={form.repeatOption}
+            onChange={handleChange}
+            className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
+          >
+            <option value="never">Never</option>
+            <option value="hourly">Every Hour</option>
+            <option value="10min">Every 10 Minutes</option>
+            <option value="custom">Custom</option>
+          </select>
+          {form.repeatOption === "custom" && (
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Hours</label>
+                <input
+                  type="number"
+                  name="customRepeatHours"
+                  value={form.customRepeatHours}
+                  onChange={handleChange}
+                  placeholder="00"
+                  className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm text-center"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Minutes</label>
+                <input
+                  type="number"
+                  name="customRepeatMinutes"
+                  value={form.customRepeatMinutes}
+                  onChange={handleChange}
+                  placeholder="00"
+                  className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm text-center"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Seconds</label>
+                <input
+                  type="number"
+                  name="customRepeatSeconds"
+                  value={form.customRepeatSeconds}
+                  onChange={handleChange}
+                  placeholder="00"
+                  className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm text-center"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const renderTimeInput = () => {
+    return (
+      <div className="space-y-3">
+        <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+          ⏰ Time to trigger {form.type === "block" ? "block" : "alert"}
+        </label>
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Hours</label>
+            <input
+              type="number"
+              name="hours"
+              value={form.hours}
+              onChange={handleChange}
+              placeholder="00"
+              className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm text-center"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Minutes</label>
+            <input
+              type="number"
+              name="minutes"
+              value={form.minutes}
+              onChange={handleChange}
+              placeholder="00"
+              className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm text-center"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Seconds</label>
+            <input
+              type="number"
+              name="seconds"
+              value={form.seconds}
+              onChange={handleChange}
+              placeholder="00"
+              className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm text-center"
+            />
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const getTypeIcon = (type) => {
+    switch (type) {
+      case "alert": return "🔔";
+      case "block": return "🚫";
+      case "custom": return "⚡";
+      default: return "📝";
+    }
+  };
+
+  const getTypeColor = (type) => {
+    switch (type) {
+      case "alert": return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
+      case "block": return "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200";
+      case "custom": return "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200";
+      default: return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200";
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-teal-50 to-green-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-4 sm:p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-4xl sm:text-5xl font-bold bg-gradient-to-r from-emerald-600 to-teal-600 bg-clip-text text-transparent mb-2">
+            🧠 Smart Reminder Settings
+          </h1>
+          <p className="text-gray-600 dark:text-gray-300 text-lg">
+            Set up intelligent reminders to boost your productivity
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-8">
+          {/* Form Section */}
+          <div className="order-2 xl:order-1">
+            <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-emerald-200 dark:border-emerald-700 p-6 sm:p-8 sticky top-4">
+              <div className="flex items-center mb-6">
+                <div className="w-12 h-12 bg-gradient-to-br from-emerald-500 to-teal-500 rounded-xl flex items-center justify-center text-white text-xl font-bold mr-4">
+                  ➕
+                </div>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Create New Reminder</h2>
+              </div>
+
+              <form onSubmit={handleSubmit} className="space-y-6">
+                {/* Reminder Type */}
+                <div className="space-y-3">
+                  <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+                    📋 Reminder Type
+                  </label>
+                  <select
+                    name="type"
+                    value={form.type}
+                    onChange={handleChange}
+                    className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
+                  >
+                    <option value="alert">🔔 Alert</option>
+                    <option value="block">🚫 Block</option>
+                    <option value="custom">⚡ Custom</option>
+                  </select>
+                </div>
+
+                {/* Custom Reminder Name */}
+                {form.type === "custom" && (
+                  <div className="space-y-3">
+                    <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+                      🏷️ Reminder Name
+                    </label>
+                    <input
+                      type="text"
+                      name="reminderName"
+                      value={form.reminderName}
+                      onChange={handleChange}
+                      className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm"
+                      placeholder="e.g. Take a walk"
+                    />
+                  </div>
+                )}
+
+                {/* Reminder Message */}
+                <div className="space-y-3">
+                  <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+                    💬 Reminder Message
+                  </label>
+                  <textarea
+                    name="message"
+                    value={form.message}
+                    onChange={handleChange}
+                    rows={3}
+                    className="w-full p-3 bg-white text-gray-900 dark:bg-slate-800 dark:text-white rounded-xl border-2 border-emerald-200 dark:border-emerald-700 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 dark:focus:ring-emerald-800 transition-all duration-200 shadow-sm resize-none"
+                    placeholder="e.g. Take a break and stretch your legs!"
+                  />
+                </div>
+
+                {/* Target Inputs */}
+                {renderTargetInputs()}
+
+                {/* Time Input */}
+                {renderTimeInput()}
+
+                {/* Repeat Options */}
+                {renderRepeatOptions()}
+
+                {/* Notification Type */}
+                <div className="space-y-3">
+                  <label className="block text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+                    🔊 Notification Type
+                  </label>
+                  <div className="grid grid-cols-2 gap-4">
+                    <label className="flex items-center p-3 bg-white dark:bg-slate-800 rounded-xl border-2 border-emerald-200 dark:border-emerald-700 cursor-pointer hover:bg-emerald-50 dark:hover:bg-slate-700 transition-colors">
+                      <input
+                        type="checkbox"
+                        value="browser"
+                        checked={form.notificationTypes.includes("browser")}
+                        onChange={handleChange}
+                        className="w-4 h-4 text-emerald-600 bg-gray-100 border-gray-300 rounded focus:ring-emerald-500 dark:focus:ring-emerald-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                      />
+                      <span className="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300">
+                        🌐 Browser
+                      </span>
+                    </label>
+                    <label className="flex items-center p-3 bg-white dark:bg-slate-800 rounded-xl border-2 border-emerald-200 dark:border-emerald-700 cursor-pointer hover:bg-emerald-50 dark:hover:bg-slate-700 transition-colors">
+                      <input
+                        type="checkbox"
+                        value="sound"
+                        checked={form.notificationTypes.includes("sound")}
+                        onChange={handleChange}
+                        className="w-4 h-4 text-emerald-600 bg-gray-100 border-gray-300 rounded focus:ring-emerald-500 dark:focus:ring-emerald-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                      />
+                      <span className="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300">
+                        🔔 Sound
+                      </span>
+                    </label>
+                  </div>
+                </div>
+
+                {/* Submit Button */}
+                <button
+                  type="submit"
+                  className="w-full bg-gradient-to-r from-emerald-500 to-teal-500 hover:from-emerald-600 hover:to-teal-600 text-white font-bold py-4 px-6 rounded-xl shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-200 flex items-center justify-center space-x-2"
+                >
+                  <span>✨</span>
+                  <span>Create Reminder</span>
+                </button>
+              </form>
+            </div>
+          </div>
+
+          {/* Reminders List */}
+          <div className="order-1 xl:order-2">
+            <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-emerald-200 dark:border-emerald-700 p-6 sm:p-8">
+              <div className="flex items-center mb-6">
+                <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-500 rounded-xl flex items-center justify-center text-white text-xl font-bold mr-4">
+                  📋
+                </div>
+                <div>
+                  <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Active Reminders</h2>
+                  <p className="text-gray-600 dark:text-gray-300 text-sm">
+                    {reminders.length} reminder{reminders.length !== 1 ? 's' : ''} configured
+                  </p>
+                </div>
+              </div>
+
+              <div className="space-y-4 max-h-96 overflow-y-auto">
+                {reminders.length === 0 ? (
+                  <div className="text-center py-12">
+                    <div className="text-6xl mb-4">🎯</div>
+                    <p className="text-gray-500 dark:text-gray-400 text-lg">No reminders yet</p>
+                    <p className="text-gray-400 dark:text-gray-500 text-sm mt-2">
+                      Create your first reminder to get started!
+                    </p>
+                  </div>
+                ) : (
+                  reminders.map((reminder) => (
+                    <div
+                      key={reminder._id}
+                      className="bg-white dark:bg-slate-700 rounded-xl shadow-md border border-gray-200 dark:border-slate-600 p-4 hover:shadow-lg transition-shadow duration-200"
+                    >
+                      <div className="flex justify-between items-start">
+                        <div className="flex-1">
+                          <div className="flex items-center mb-2">
+                            <span className="text-lg mr-2">{getTypeIcon(reminder.type)}</span>
+                            <span className={`px-2 py-1 rounded-full text-xs font-medium ${getTypeColor(reminder.type)}`}>
+                              {reminder.type.toUpperCase()}
+                            </span>
+                          </div>
+                          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+                            {reminder.reminderName || "Reminder"}
+                          </h3>
+                          <p className="text-gray-600 dark:text-gray-300 text-sm mb-2">
+                            {reminder.message}
+                          </p>
+                          <div className="flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400">
+                            <span className="bg-gray-100 dark:bg-gray-600 px-2 py-1 rounded-full">
+                              ⏰ {reminder.hours}h {reminder.minutes}m {reminder.seconds}s
+                            </span>
+                            {reminder.repeatOption === "custom" && (
+                              <span className="bg-gray-100 dark:bg-gray-600 px-2 py-1 rounded-full">
+                                🔄 {reminder.customRepeatHours}h {reminder.customRepeatMinutes}m {reminder.customRepeatSeconds}s
+                              </span>
+                            )}
+                            {reminder.repeatOption !== "never" && reminder.repeatOption !== "custom" && (
+                              <span className="bg-gray-100 dark:bg-gray-600 px-2 py-1 rounded-full">
+                                🔄 {reminder.repeatOption}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <button
+                          onClick={() => handleDelete(reminder._id)}
+                          className="ml-4 text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 p-2 rounded-full transition-colors duration-200"
+                        >
+                          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+              <div ref={remindersEndRef} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Reminders;

--- a/server/controllers/reminder.controller.js
+++ b/server/controllers/reminder.controller.js
@@ -1,0 +1,50 @@
+import Reminder from "../models/reminder.model.js";
+
+export const addReminder = async (req, res) => {
+  try {
+    const newReminder = new Reminder({
+      ...req.body,
+      userId: req.user.id
+    });
+
+    await newReminder.save();
+
+    // ✅ Send wrapped response
+    res.status(201).json({ reminder: newReminder });
+  } catch (error) {
+    console.error("Error adding reminder:", error);
+    res.status(500).json({ error: error.message });
+  }
+};
+
+export const getUserReminders = async (req, res) => {
+  try {
+    const reminders = await Reminder.find({ userId: req.user.id }).sort({ createdAt: -1 });
+    res.status(200).json(reminders);
+  } catch (error) {
+    console.error("Error getting reminders:", error);
+    res.status(500).json({ error: error.message });
+  }
+};
+
+export const deleteReminder = async (req, res) => {
+  try {
+    await Reminder.findByIdAndDelete(req.params.id);
+    res.status(200).json({ message: "Reminder deleted" });
+  } catch (error) {
+    console.error("Error deleting reminder:", error);
+    res.status(500).json({ error: error.message });
+  }
+};
+
+export const updateReminder = async (req, res) => {
+  try {
+    const updated = await Reminder.findByIdAndUpdate(req.params.id, req.body, {
+      new: true
+    });
+    res.status(200).json(updated);
+  } catch (error) {
+    console.error("Error updating reminder:", error);
+    res.status(500).json({ error: error.message });
+  }
+};

--- a/server/models/reminder.model.js
+++ b/server/models/reminder.model.js
@@ -1,0 +1,47 @@
+import mongoose from "mongoose";
+
+const reminderSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+
+  type: {
+    type: String,
+    enum: ["alert", "block", "custom"],
+    required: true,
+  },
+
+  // alert + block + custom
+  reminderName: { type: String },
+  message: { type: String, default: "" },
+
+  // Target (used in alert + block)
+  targetType: { type: String, enum: ["category", "domain"], default: "domain" },
+  targetValue: { type: String },
+
+  // Main time to trigger the reminder (used in all types) 
+  hours: { type: Number, default: 0 },
+  minutes: { type: Number, default: 0 },
+  seconds: { type: Number, default: 0 },
+
+  // Notification types
+  notificationTypes: {
+    type: [String],
+    enum: ["browser", "sound"],
+    default: ["browser"],
+  },
+
+  // Repeat configuration for alert-type
+  repeatOption: {
+    type: String,
+    enum: ["never", "hourly", "10min", "custom"],
+    default: "never",
+  },
+  customRepeatHours: { type: Number, default: 0 },
+  customRepeatMinutes: { type: Number, default: 0 },
+  customRepeatSeconds: { type: Number, default: 0 },
+
+  active: { type: Boolean, default: true },
+  createdAt: { type: Date, default: Date.now }
+});
+
+const Reminder = mongoose.model("Reminder", reminderSchema);
+export default Reminder;

--- a/server/routes/reminder.route.js
+++ b/server/routes/reminder.route.js
@@ -1,0 +1,17 @@
+import express from "express";
+import {
+  addReminder,
+  getUserReminders,
+  deleteReminder,
+  updateReminder,
+} from "../controllers/reminder.controller.js";
+import authenticate from "../middleware/auth.middleware.js";
+
+const router = express.Router();
+
+router.post("/add", authenticate, addReminder);
+router.get("/user", authenticate, getUserReminders);
+router.delete("/:id", authenticate, deleteReminder);
+router.put("/:id", authenticate, updateReminder);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,7 @@ import authRouter from "./routes/auth.route.js";
 import trackingRouter from "./routes/tracking.route.js";
 import activityRouter from "./routes/activity.route.js";
 import domainRouter from "./routes/domain.route.js"; // For domain time tracking
+import reminderRouter from "./routes/reminder.route.js"; // ✅ Reminder Feature
 
 // App setup
 const app = express();
@@ -65,7 +66,8 @@ app.use("/api/users", userRouter);
 app.use("/api/auth", authRouter);
 app.use("/api/tracking", trackingRouter);
 app.use("/api/activity", activityRouter); // Activity logging
-app.use("/api/domain", domainRouter); // Time tracking
+app.use("/api/domain", domainRouter);     // Time tracking
+app.use("/api/reminders", reminderRouter); // ✅ Reminder routes
 
 // Health check route
 app.get("/api/health", (req, res) => {
@@ -74,5 +76,5 @@ app.get("/api/health", (req, res) => {
 
 // Start server
 app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
+  console.log(`🚀 Server listening on port ${port}`);
 });


### PR DESCRIPTION
Added support for 3 reminder types: alert, block, and custom.

For alert, user selects category or custom domain + sets time + optional repeat after first alert.

For block, user enters a domain and sets block time (no category needed).

For custom, user enters name, message, and total screen time trigger (no domain/category).

Time inputs now accept hours, minutes, and seconds.

Custom repeat interval supported (HH:MM:SS).

New reminders appear instantly on the page after creation.

Reminder cards redesigned with WhatsApp-style green theme.
#85 
